### PR TITLE
INSP-1980, INSP-2103 - Presence validation and pagination

### DIFF
--- a/lib/contentful_model/base.rb
+++ b/lib/contentful_model/base.rb
@@ -47,7 +47,7 @@ module ContentfulModel
       # we need to pull out any Contentful::Link references, and also things which don't have any fields at all
       # because they're newly created
       if result.is_a?(Array)
-        result.reject! {|r| r.is_a?(Contentful::Link) || (r.respond_to?(:invalid) && r.invalid?)}
+        result.reject! { |r| r.is_a?(Contentful::Link) || (r.respond_to?(:invalid?) && r.invalid?) }
       elsif result.is_a?(Contentful::Link)
         result = nil
       elsif result.respond_to?(:fields) && result.send(:fields).empty?

--- a/lib/contentful_model/query.rb
+++ b/lib/contentful_model/query.rb
@@ -17,7 +17,8 @@ module ContentfulModel
     def execute
       query = @parameters.merge(default_parameters)
       result = client.send(:entries,query)
-      return result.to_a.reject {|entity| entity.is_a?(Contentful::Link) || entity.invalid?}
+      result.items.reject! { |entity| entity.is_a?(Contentful::Link) || entity.invalid? }
+      result
     end
 
     def client

--- a/lib/contentful_model/validations/validates_presence_of.rb
+++ b/lib/contentful_model/validations/validates_presence_of.rb
@@ -24,7 +24,7 @@ module Contentful
         errors = []
 
         fields.each do |field|
-          errors << "#{field} is required" unless entry.respond_to?(field) && (entry.try(field) rescue nil).present?
+          errors << "#{field} is required" unless entry.respond_to?(field) && (entry.send(field) rescue nil).present?
         end
 
         errors

--- a/lib/contentful_model/validations/validates_presence_of.rb
+++ b/lib/contentful_model/validations/validates_presence_of.rb
@@ -24,7 +24,7 @@ module Contentful
         errors = []
 
         fields.each do |field|
-          errors << "#{field} is required" unless entry.respond_to?(field) && entry.try(field).present?
+          errors << "#{field} is required" unless entry.respond_to?(field) && (entry.try(field) rescue nil).present?
         end
 
         errors

--- a/lib/contentful_model/validations/validates_presence_of.rb
+++ b/lib/contentful_model/validations/validates_presence_of.rb
@@ -24,7 +24,7 @@ module Contentful
         errors = []
 
         fields.each do |field|
-          errors << "#{field} is required" unless entry.respond_to?(field)
+          errors << "#{field} is required" unless entry.respond_to?(field) && entry.try(field).present?
         end
 
         errors


### PR DESCRIPTION
* Fixing their PresenceValidator, since it only checked if the entry `responds_to?` the method which will return `true` even if the association is `nil`
* Fixing their `method_missing` where it checks the validity of the objects being loaded.  This was resulting in "invalid" entries being returned for associations.  Ex: `@ideas_root_section.spotlight_posts` could return content entries that are invalid, because their `.content_body` was nil.
* Fixing their query class to not call `to_a` on the main `results` object.  This object is a `Contentful::Array` which contains all the necessary pagination meta information (total results) and calling `to_a` converts that object into an array and loses that meta data.